### PR TITLE
Spilt Route and URL attributes in log

### DIFF
--- a/lib/logger-helper.js
+++ b/lib/logger-helper.js
@@ -66,6 +66,7 @@ function getRequestAudit(req, options){
     var requestURL = utils.getUrl(req);
     var queryParams = req && req.query !== {} ? req.query : NA;
     var method = req && req.method ? req.method : NA;
+    var URLParams = req && req.params ? req.params : NA;
     var timestamp = req && req.timestamp ? req.timestamp.toISOString() : NA;
     var timestamp_ms = req && req.timestamp ? req.timestamp.valueOf() : NA;
 
@@ -89,6 +90,7 @@ function getRequestAudit(req, options){
 
     var auditObject = {
         method: method,
+        url_params: URLParams,
         url: requestURL,
         query: queryParams,
         headers: headers,

--- a/lib/logger-helper.js
+++ b/lib/logger-helper.js
@@ -63,7 +63,8 @@ var auditResponse = function(req, res, options){
 
 function getRequestAudit(req, options){
     var headers = req && req.headers ? req.headers : NA;
-    var requestURL = utils.getUrl(req);
+    var requestFullURL = utils.getUrl(req);
+    var requestRoute = utils.getRoute(req);
     var queryParams = req && req.query !== {} ? req.query : NA;
     var method = req && req.method ? req.method : NA;
     var URLParams = req && req.params ? req.params : NA;
@@ -91,7 +92,8 @@ function getRequestAudit(req, options){
     var auditObject = {
         method: method,
         url_params: URLParams,
-        url: requestURL,
+        url: requestFullURL,
+        url_route: requestRoute,
         query: queryParams,
         headers: headers,
         timestamp: timestamp,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,12 @@ const NA = 'N/A';
 var getUrl = function(req){
     var url = req && req.url || NA;
 
+    return url;
+};
+
+var getRoute = function(req) {
+    var url = NA;
+
     if (req){
         var route = req.baseUrl;
         if (req.route && route){
@@ -15,7 +21,7 @@ var getUrl = function(req){
     }
 
     return url;
-};
+}
 
 var maskJson = function(jsonObj, fieldsToMask){
     let jsonObjCopy = _.cloneDeepWith(jsonObj, function (value, key) {
@@ -34,6 +40,7 @@ var shouldAuditURL = function(excludeURLs, req){
 };
 
 module.exports = {
+    getRoute: getRoute,
     getUrl: getUrl,
     maskJson: maskJson,
     shouldAuditURL: shouldAuditURL

--- a/test/logger-helper-test.js
+++ b/test/logger-helper-test.js
@@ -31,6 +31,7 @@ describe('logger-helpers tests', function(){
     var expectedAuditRequest = {
         method: method,
         url: url,
+        url_route: '/somepath/:id',
         query: query,
         headers: {
             header1: 'some-value'
@@ -61,6 +62,10 @@ describe('logger-helpers tests', function(){
             request = httpMocks.createRequest({
                 method: method,
                 url: url,
+                route: {
+                    path: '/:id'
+                },
+                baseUrl: '/somepath',
                 params: params,
                 query: query,
                 body: body,
@@ -218,6 +223,10 @@ describe('logger-helpers tests', function(){
             request = httpMocks.createRequest({
                 method: method,
                 url: url,
+                route: {
+                    path: '/:id'
+                },
+                baseUrl: '/somepath',
                 query: query,
                 body: body,
                 headers: {
@@ -256,6 +265,17 @@ describe('logger-helpers tests', function(){
             });
         });
         describe('And shouldAuditURL returns true', function(){
+            it('Should audit request if options.request.audit is true', function(){
+                shouldAuditURLStub.returns(true);
+                options.request.audit = true;
+                clock.tick(elapsed);
+                loggerHelper.auditResponse(request, response, options);
+                sinon.assert.calledOnce(loggerInfoStub);
+                sinon.assert.calledWith(loggerInfoStub, {
+                    request: expectedAuditRequest,
+                    response: expectedAuditResponse
+                });
+            });
             it('Should audit request if options.request.audit is true', function(){
                 shouldAuditURLStub.returns(true);
                 options.request.audit = true;
@@ -312,6 +332,7 @@ describe('logger-helpers tests', function(){
                     request: {
                         method: NA,
                         url: NA,
+                        url_route: NA,
                         query: NA,
                         url_params: NA,
                         headers: NA,

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -18,14 +18,36 @@ describe('utils tests', function(){
             var url = utils.getUrl(request);
             should(url).eql(expectedPath);
         });
-        it('Should return url for a path with route', function(){
+        it('Should return url for a path - route doesn\'t change the url', function(){
             request.baseUrl = 'path';
             request.route = {
-                path: '/123'
+                path: '/:id'
             };
 
             var url = utils.getUrl(request);
             should(url).eql(expectedPath);
+        });
+        it('Should N/A for not valid req obj', function(){
+            var url = utils.getUrl(undefined);
+            should(url).eql('N/A');
+        });
+    });
+
+    describe('When calling getRoute', function(){
+        var request;
+        var expectedRoute = '/path/:id';
+        beforeEach(function(){
+            request = httpMocks.createRequest({
+                method: 'POST',
+                route: {
+                    path: '/:id'
+                },
+                baseUrl: '/path',
+            });
+        });
+        it('Should return url_route for a path', function(){
+            var url_route = utils.getRoute(request);
+            should(url_route).eql(expectedRoute);
         });
         it('Should N/A for not valid req obj', function(){
             var url = utils.getUrl(undefined);


### PR DESCRIPTION
I split express route and full url attributes in the logs.

the old `url` contain always the full path and a new attribute `route_url` will contain the express route in case it exists.